### PR TITLE
Feature/plaid transactions v2

### DIFF
--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -20,7 +20,8 @@ export const Button = ({
 			break
 
 		case 'clear':
-			base += ' bg-white border-3 border-gray-200 hover:bg-slate-950 hover:text-white hover:border-slate-950'
+			base +=
+				' bg-white border-3 border-gray-200 hover:bg-slate-950 hover:text-white hover:border-slate-950'
 			break
 
 		default:

--- a/client/src/components/GenerateHandshakeCodeModal.tsx
+++ b/client/src/components/GenerateHandshakeCodeModal.tsx
@@ -7,10 +7,10 @@ const GenerateHandshakeCodeModal = ({ onClick }: { onClick: () => void }) => {
 
 	useEffect(() => {
 		fetch('/api/pair/request')
-			.then(res => res.json())
-			.then(data => setCode(data.code))
-			.catch(err => console.error(err))
-    }, [])
+			.then((res) => res.json())
+			.then((data) => setCode(data.code))
+			.catch((err) => console.error(err))
+	}, [])
 
 	return (
 		<div className="h-screen w-screen bg-gray-400/10 absolute flex justify-center items-center">
@@ -20,7 +20,8 @@ const GenerateHandshakeCodeModal = ({ onClick }: { onClick: () => void }) => {
 				</h1>
 				<p className="self-start text-gray-500 font-light text-md">
 					This code allows you to pair with your partner. Give them
-					this code in order to pair. This code will expire in 5 minutes.
+					this code in order to pair. This code will expire in 5
+					minutes.
 				</p>
 
 				<Input

--- a/client/src/components/WithAuth.tsx
+++ b/client/src/components/WithAuth.tsx
@@ -2,8 +2,6 @@ import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useUser } from '../contexts/UserContext'
 
-// TODO: allow reload on site without triggering user log in
-
 export const WithAuth = (WrappedComponent: React.ComponentType<object>) => {
 	return function ProtectedComponent(props: object) {
 		const { user, loading } = useUser()

--- a/client/src/contexts/UserContext.tsx
+++ b/client/src/contexts/UserContext.tsx
@@ -1,9 +1,27 @@
-import { createContext, useState, useContext, useEffect } from 'react'
+import { createContext, useState, useContext, useEffect, type SetStateAction, type Dispatch } from 'react'
 
-const UserContext = createContext<any>(undefined) // Find typing for usercontext
+type User = {
+	id: string,
+	name: string,
+	email: string
+}
+
+interface UserContextType {
+	user: User | null
+	loading: boolean
+	setUser: Dispatch<SetStateAction<User | null>>
+}
+
+const defaultUserContext: UserContextType = {
+	user: null,
+	loading: true,
+	setUser: () => {},
+}
+
+const UserContext = createContext<UserContextType>(defaultUserContext) // Find typing for usercontext
 
 export const UserProvider = ({ children }: { children: React.ReactNode }) => {
-	const [user, setUser] = useState(null)
+	const [user, setUser] = useState<User | null>(null)
 	const [loading, setLoading] = useState(true)
 
 	useEffect(() => {

--- a/client/src/contexts/UserContext.tsx
+++ b/client/src/contexts/UserContext.tsx
@@ -25,7 +25,7 @@ const defaultUserContext: UserContextType = {
 	setUser: () => {},
 }
 
-const UserContext = createContext<UserContextType>(defaultUserContext) // Find typing for usercontext
+const UserContext = createContext<UserContextType>(defaultUserContext)
 
 export const UserProvider = ({ children }: { children: React.ReactNode }) => {
 	const [user, setUser] = useState<User | null>(null)

--- a/client/src/contexts/UserContext.tsx
+++ b/client/src/contexts/UserContext.tsx
@@ -1,8 +1,15 @@
-import { createContext, useState, useContext, useEffect, type SetStateAction, type Dispatch } from 'react'
+import {
+	createContext,
+	useState,
+	useContext,
+	useEffect,
+	type SetStateAction,
+	type Dispatch,
+} from 'react'
 
 type User = {
-	id: string,
-	name: string,
+	id: string
+	name: string
 	email: string
 }
 

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -10,7 +10,7 @@ const Dashboard = () => {
 
 	const fetchAccounts = async () => {
 		try {
-			const response = await fetch('/api/plaid/accounts', {
+			const response = await fetch('/api/plaid/accounts/get', {
 				headers: { 'Content-Type' : 'application/json' }
 			})
 			const data = await response.json()
@@ -52,10 +52,10 @@ const Dashboard = () => {
 			{user ? <p>Hello, {user.name}</p> : <p>Hello, User</p>}
 
 			<p className='text-3xl'>Acccounts</p>
-			{loading ? 'loading ...' : JSON.stringify(accounts)}
+			{loading ? 'loading ...' : <pre>{JSON.stringify(accounts, null, "\t")}</pre>}
 
 			<p className='text-3xl'>Transactions</p>
-			{loading ? 'loading ...' : JSON.stringify(transactions)}
+			{loading ? 'loading ...' : <pre>{JSON.stringify(transactions, null, 4)}</pre>}
 
 			<LogoutButton />
 		</div>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { LogoutButton } from '../components/LogoutButton'
 import { useUser } from '../contexts/UserContext'
 
@@ -13,12 +13,15 @@ const Dashboard = () => {
 			})
 			const data = await response.json()
 
-			console.log(data)
-
+			setAccounts(data)
 		} catch(err) {
 			console.error(err)
 		}
 	}
+
+	useEffect(() => {
+		fetchAccounts()
+	})
 
 	return (
 		<div>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,10 +1,24 @@
+import { useState } from 'react'
 import { LogoutButton } from '../components/LogoutButton'
 import { useUser } from '../contexts/UserContext'
 
 const Dashboard = () => {
 	const { user } = useUser()
+	const [accounts, setAccounts] = useState({})
 
-	
+	const fetchAccounts = async () => {
+		try {
+			const response = await fetch('/api/plaid/accounts', {
+				headers: { 'Content-Type' : 'application/json' }
+			})
+			const data = await response.json()
+
+			console.log(data)
+
+		} catch(err) {
+			console.error(err)
+		}
+	}
 
 	return (
 		<div>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -21,7 +21,7 @@ const Dashboard = () => {
 
 	useEffect(() => {
 		fetchAccounts()
-	})
+	}, [])
 
 	return (
 		<div>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -49,7 +49,7 @@ const Dashboard = () => {
 
 	return (
 		<div>
-			{user ? <p>Hello, {user.name}</p> : <p>Hello, User</p>}
+			{user ? <p className='capitalize'>Hello, {user.name}</p> : <p>Hello, User</p>}
 
 			<p className='text-3xl'>Acccounts</p>
 			{loading ? 'loading ...' : <pre>{JSON.stringify(accounts, null, "\t")}</pre>}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -4,7 +4,9 @@ import { useUser } from '../contexts/UserContext'
 
 const Dashboard = () => {
 	const { user } = useUser()
-	const [accounts, setAccounts] = useState({})
+	const [accounts, setAccounts] = useState(null)
+	const [transactions, setTransactions] = useState(null)
+	const [loading, setLoading] = useState(true)
 
 	const fetchAccounts = async () => {
 		try {
@@ -19,13 +21,41 @@ const Dashboard = () => {
 		}
 	}
 
+	const fetchTransactions = async () => {
+		const response = await fetch('/api/plaid/transactions/list', {
+			headers: { 'Content-Type' : 'application/json' }
+		})
+		const data = await response.json()
+		setTransactions(data)
+	}
+
+	const syncTransactions = async () => {
+		try {
+			await fetch('/api/plaid/transactions/sync', {
+				headers: { 'Content-Type' : 'application/json' }
+			})
+		} catch (err) {
+			console.error(err)
+		}
+	}
+
 	useEffect(() => {
+		setLoading(true)
 		fetchAccounts()
+		syncTransactions()
+		fetchTransactions()
+		setLoading(false)
 	}, [])
 
 	return (
 		<div>
 			{user ? <p>Hello, {user.name}</p> : <p>Hello, User</p>}
+
+			<p className='text-3xl'>Acccounts</p>
+			{loading ? 'loading ...' : JSON.stringify(accounts)}
+
+			<p className='text-3xl'>Transactions</p>
+			{loading ? 'loading ...' : JSON.stringify(transactions)}
 
 			<LogoutButton />
 		</div>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -11,19 +11,19 @@ const Dashboard = () => {
 	const fetchAccounts = async () => {
 		try {
 			const response = await fetch('/api/plaid/accounts/get', {
-				headers: { 'Content-Type' : 'application/json' }
+				headers: { 'Content-Type': 'application/json' },
 			})
 			const data = await response.json()
 
 			setAccounts(data)
-		} catch(err) {
+		} catch (err) {
 			console.error(err)
 		}
 	}
 
 	const fetchTransactions = async () => {
 		const response = await fetch('/api/plaid/transactions/list', {
-			headers: { 'Content-Type' : 'application/json' }
+			headers: { 'Content-Type': 'application/json' },
 		})
 		const data = await response.json()
 		setTransactions(data)
@@ -32,7 +32,7 @@ const Dashboard = () => {
 	const syncTransactions = async () => {
 		try {
 			await fetch('/api/plaid/transactions/sync', {
-				headers: { 'Content-Type' : 'application/json' }
+				headers: { 'Content-Type': 'application/json' },
 			})
 		} catch (err) {
 			console.error(err)
@@ -49,13 +49,25 @@ const Dashboard = () => {
 
 	return (
 		<div>
-			{user ? <p className='capitalize'>Hello, {user.name}</p> : <p>Hello, User</p>}
+			{user ? (
+				<p className="capitalize">Hello, {user.name}</p>
+			) : (
+				<p>Hello, User</p>
+			)}
 
-			<p className='text-3xl'>Acccounts</p>
-			{loading ? 'loading ...' : <pre>{JSON.stringify(accounts, null, "\t")}</pre>}
+			<p className="text-3xl">Acccounts</p>
+			{loading ? (
+				'loading ...'
+			) : (
+				<pre>{JSON.stringify(accounts, null, '\t')}</pre>
+			)}
 
-			<p className='text-3xl'>Transactions</p>
-			{loading ? 'loading ...' : <pre>{JSON.stringify(transactions, null, 4)}</pre>}
+			<p className="text-3xl">Transactions</p>
+			{loading ? (
+				'loading ...'
+			) : (
+				<pre>{JSON.stringify(transactions, null, 4)}</pre>
+			)}
 
 			<LogoutButton />
 		</div>

--- a/client/src/pages/LinkPlaid.tsx
+++ b/client/src/pages/LinkPlaid.tsx
@@ -27,18 +27,18 @@ const LinkPlaid = () => {
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({ public_token: public_token }),
 			})
-			.then(res => res.json())
-			.then(data => {
-				if (data.error) {
-					setIsError(true)
-				} else {
-					navigate('/pair')
-				}
-			})
+				.then((res) => res.json())
+				.then((data) => {
+					if (data.error) {
+						setIsError(true)
+					} else {
+						navigate('/pair')
+					}
+				})
 		} catch (error: any) {
 			console.log(error.message)
 		}
-		
+
 		setLoading(false)
 	}, [])
 
@@ -70,9 +70,19 @@ const LinkPlaid = () => {
 				Connect bank via Plaid to continue creating your account.
 			</h1>
 
-			{isError ? <p className='bg-red-200 py-4 px-8 rounded-md border-red-700 border-4 text-red-700 font-medium text-lg'>Error connecting bank</p> : <></>}
+			{isError ? (
+				<p className="bg-red-200 py-4 px-8 rounded-md border-red-700 border-4 text-red-700 font-medium text-lg">
+					Error connecting bank
+				</p>
+			) : (
+				<></>
+			)}
 
-			<Button onClick={() => open()} disabled={!ready} className={loading ? 'bg-amber-300' : ''}>
+			<Button
+				onClick={() => open()}
+				disabled={!ready}
+				className={loading ? 'bg-amber-300' : ''}
+			>
 				Connect Bank
 			</Button>
 		</div>

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -7,13 +7,14 @@ import { Input } from '../components/Input'
 
 const LoginPage = () => {
 	const [loginData, setLoginData] = useState({ email: '', password: '' })
-	const [error] = useState('')
+	const [error, setError] = useState('')
 	const { setUser } = useUser()
 	const navigate = useNavigate()
 
 	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const { name, value } = e.target
 		setLoginData((prev) => ({ ...prev, [name]: value }))
+		setError('')
 	}
 
 	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -27,8 +28,14 @@ const LoginPage = () => {
 			})
 
 			const data = await response.json()
-			setUser(data)
 
+			if (!response.ok) {
+				setError(data.error)
+				return
+			} 
+			
+			setUser(data)
+			
 			if (!data.is_plaid_linked) {
 				navigate('/connect-bank')
 			} else if (!data.is_paired) {
@@ -36,6 +43,7 @@ const LoginPage = () => {
 			} else {
 				navigate('/dashboard')
 			}
+
 		} catch (error) {
 			console.error('Network Error: Please try again', error)
 		}

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -31,7 +31,7 @@ const LoginPage = () => {
 			setUser(data)
 			
 			// TODO: fixed navigation on log in
-			if (!data.is_plaid_link) {
+			if (!data.is_plaid_linked) {
 				navigate('/connect-bank')
 			} else if (!data.is_paired) {
 				navigate('/pair')

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -32,10 +32,10 @@ const LoginPage = () => {
 			if (!response.ok) {
 				setError(data.error)
 				return
-			} 
-			
+			}
+
 			setUser(data)
-			
+
 			if (!data.is_plaid_linked) {
 				navigate('/connect-bank')
 			} else if (!data.is_paired) {
@@ -43,7 +43,6 @@ const LoginPage = () => {
 			} else {
 				navigate('/dashboard')
 			}
-
 		} catch (error) {
 			console.error('Network Error: Please try again', error)
 		}

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -20,7 +20,6 @@ const LoginPage = () => {
 		e.preventDefault()
 
 		try {
-			// REMOVE localhost:3000 during development
 			const response = await fetch('/api/auth/login', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
@@ -30,7 +29,6 @@ const LoginPage = () => {
 			const data = await response.json()
 			setUser(data)
 
-			// TODO: fixed navigation on log in
 			if (!data.is_plaid_linked) {
 				navigate('/connect-bank')
 			} else if (!data.is_paired) {

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -29,7 +29,7 @@ const LoginPage = () => {
 
 			const data = await response.json()
 			setUser(data)
-			
+
 			// TODO: fixed navigation on log in
 			if (!data.is_plaid_linked) {
 				navigate('/connect-bank')

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -29,7 +29,8 @@ const LoginPage = () => {
 
 			const data = await response.json()
 			setUser(data)
-
+			
+			// TODO: fixed navigation on log in
 			if (!data.plaidToken) {
 				navigate('/connect-bank')
 			} else if (!data.partnerId) {

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -33,7 +33,7 @@ const LoginPage = () => {
 			// TODO: fixed navigation on log in
 			if (!data.plaidToken) {
 				navigate('/connect-bank')
-			} else if (!data.partnerId) {
+			} else if (!data.partner_id) {
 				navigate('/pair')
 			} else {
 				navigate('/dashboard')

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -31,9 +31,9 @@ const LoginPage = () => {
 			setUser(data)
 			
 			// TODO: fixed navigation on log in
-			if (!data.plaidToken) {
+			if (!data.is_plaid_link) {
 				navigate('/connect-bank')
-			} else if (!data.partner_id) {
+			} else if (!data.is_paired) {
 				navigate('/pair')
 			} else {
 				navigate('/dashboard')

--- a/client/src/pages/PairPage.tsx
+++ b/client/src/pages/PairPage.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react'
 import GenerateHandshakeCodeModal from '../components/GenerateHandshakeCodeModal'
 import EnterHandshakeCodeModal from '../components/EnterHandshakeCodeModal'
 import { useUser } from '../contexts/UserContext'
-import { capitalize } from '../utils/utils'
 
 const PairPage = () => {
 	const [showGenerateHandshakeCodeModal, setShowGenerateHandshakeCodeModal] =
@@ -45,9 +44,8 @@ const PairPage = () => {
 			</Link>
 
 			<div className="flex flex-col justify-center items-center gap-4 w-md relative">
-				<h1 className="text-center text-3xl">
-					{capitalize(user?.name)} it's time to pair with your
-					partner.
+				<h1 className="text-center text-3xl capitalize">
+					{user?.name} it's time to pair with your partner.
 				</h1>
 
 				<Button

--- a/server/index.ts
+++ b/server/index.ts
@@ -15,8 +15,7 @@ declare module 'express-session' {
 			id: string
 			name: string
 			email: string
-			plaidToken: string
-			partnerId: string
+			partner_id?: string
 		}
 	}
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -16,7 +16,7 @@ datasource db {
 
 model User {
   id              String    @id @default(uuid())
-  createdAt       DateTime  @default(now())
+  created_at       DateTime  @default(now())
   email           String    @unique
   password        String    
   name            String
@@ -54,7 +54,8 @@ model Accounts {
   id        String  @id
   item_id   String
   name      String?
-  pairId    String?
+  pair_id    String?
+  user_id   String
 }
 
 model Transactions {

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -20,22 +20,53 @@ model User {
   email           String    @unique
   password        String    
   name            String
-  plaidToken      String?    @unique
-  plaidItemId     String?    @unique
-  partnerId       String?
+  partner_id      String?   @unique
+  partner         User?   @relation("UserToPartner", fields: [partner_id], references: [id])
+  partnerOf       User?   @relation("UserToPartner")
 }
 
 model PairRequest {
   id                  String    @id @default(uuid())
   code                String    @unique
-  initiatorUserId     String    
+  initiator_user_id     String    
   status              String    @default("PENDING")
-  createdAt           DateTime  @default(now())  
+  created_at           DateTime  @default(now())  
 }
 
 model Pair {
   id        String @id @default(uuid())
-  user1Id   String @unique
-  user2Id   String @unique  
-  pairedAt  DateTime @default(now())
+  user1_id   String @unique
+  user2_id   String @unique  
+  paired_at  DateTime @default(now())
+}
+
+model PlaidItem {
+  id            String  @id
+  access_token  String  @unique
+  owner_id       String  @unique  
+  is_active      Boolean @default(true) 
+  transaction_cursor  String?
+  bank  String?
+  created_at    DateTime  @default(now())
+}
+
+model Accounts {
+  id        String  @id
+  item_id   String
+  name      String?
+  pairId    String?
+}
+
+model Transactions {
+  id              String    @id
+  user_id         String
+  pair_id         String
+  account_id      String
+  category        String
+  date            String
+  authorized_date String
+  name            String
+  amount          Float
+  currency_code   String
+  is_removed      Boolean @default(false)
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -23,6 +23,7 @@ model User {
   partner_id      String?   @unique
   partner         User?   @relation("UserToPartner", fields: [partner_id], references: [id])
   partnerOf       User?   @relation("UserToPartner")
+  transactions    Transactions[]
 }
 
 model PairRequest {
@@ -48,21 +49,26 @@ model PlaidItem {
   transaction_cursor  String?
   bank  String?
   created_at    DateTime  @default(now())
+  accounts    Accounts[]
 }
 
 model Accounts {
   id        String  @id
   item_id   String
+  item      PlaidItem @relation(fields: [item_id], references:[id])
   name      String?
   pair_id    String?
   user_id   String
+  transactions Transactions[]
 }
 
 model Transactions {
   id              String    @id
   user_id         String
+  user            User      @relation(fields:[user_id], references:[id])
   pair_id         String
-  account_id      String
+  account_id      String      
+  account         Accounts   @relation(fields:[account_id], references:[id])
   category        String
   date            String
   authorized_date String

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -24,6 +24,8 @@ model User {
   partner         User?   @relation("UserToPartner", fields: [partner_id], references: [id])
   partnerOf       User?   @relation("UserToPartner")
   transactions    Transactions[]
+  is_plaid_linked Boolean   @default(false)
+  is_paired   Boolean   @default(false)
 }
 
 model PairRequest {

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -71,10 +71,10 @@ auth.post('/login', loginLimiter, async (req: Request, res: Response) => {
 	}
 
 	const user = await prisma.user.findUnique({
-		where: { email },
+		where: { email: email },
 	})
 
-	if (!user || !(await bcrypt.compare(password, user.password))) {
+	if (!user || !(await bcrypt.compare(password, user?.password))) {
 		res.status(400).json({ error: 'Invalid email or password ' })
 		return
 	}

--- a/server/routes/pair.ts
+++ b/server/routes/pair.ts
@@ -16,13 +16,13 @@ pair.get('/request', isAuthenticated, async (req: Request, res: Response) => {
 	const userId = req.session.user.id
 
 	const codeRequest = await prisma.pairRequest.findFirst({
-		where: { initiatorUserId: userId },
+		where: { initiator_user_id: userId },
 		orderBy: {
-			createdAt: 'desc',
+			created_at: 'desc',
 		},
 	})
 
-	if (codeRequest && !isExpired(codeRequest.createdAt, EXPIRATION_DURATION)) {
+	if (codeRequest && !isExpired(codeRequest.created_at, EXPIRATION_DURATION)) {
 		res.status(200).json({
 			message: 'You already initiated a pair request',
 			...codeRequest,
@@ -34,7 +34,7 @@ pair.get('/request', isAuthenticated, async (req: Request, res: Response) => {
 	const pairRequest = await prisma.pairRequest.create({
 		data: {
 			code: code,
-			initiatorUserId: userId,
+			initiator_user_id: userId,
 		},
 	})
 
@@ -48,7 +48,7 @@ pair.post('/enter', isAuthenticated, async (req, res) => {
 	const code = req.body.code
 	const userId = req.session.user.id
 
-	if (req.session.user.partnerId) {
+	if (req.session.user.partner_id) {
 		res.status(400).json({
 			message: 'You are already paired with another user.',
 		})
@@ -61,8 +61,8 @@ pair.post('/enter', isAuthenticated, async (req, res) => {
 			status: 'PENDING',
 		},
 		select: {
-			initiatorUserId: true,
-			createdAt: true,
+			initiator_user_id: true,
+			created_at: true,
 		},
 	})
 
@@ -71,9 +71,9 @@ pair.post('/enter', isAuthenticated, async (req, res) => {
 		return
 	}
 
-	const partnerId = pairRequest.initiatorUserId
+	const partnerId = pairRequest.initiator_user_id
 
-	if (isExpired(pairRequest.createdAt, EXPIRATION_DURATION)) {
+	if (isExpired(pairRequest.created_at, EXPIRATION_DURATION)) {
 		res.status(410).json({ error: 'Pairing code expired' })
 		return
 	}
@@ -85,12 +85,12 @@ pair.post('/enter', isAuthenticated, async (req, res) => {
 
 	await prisma.user.update({
 		where: { id: userId },
-		data: { partnerId: partnerId },
+		data: { partner_id: partnerId },
 	})
 
 	await prisma.user.update({
 		where: { id: partnerId },
-		data: { partnerId: userId },
+		data: { partner_id: userId },
 	})
 
 	await prisma.pairRequest.update({
@@ -102,8 +102,8 @@ pair.post('/enter', isAuthenticated, async (req, res) => {
 
 	await prisma.pair.create({
 		data: {
-			user1Id: userId,
-			user2Id: partnerId,
+			user1_id: userId,
+			user2_id: partnerId,
 		},
 	})
 

--- a/server/routes/plaid.ts
+++ b/server/routes/plaid.ts
@@ -73,7 +73,7 @@ plaid.post('/create_link_token', isAuthenticated, async (req, res) => {
 	}
 })
 
-plaid.post('/exchange_public_token', async (req, res) => {
+plaid.post('/exchange_public_token', isAuthenticated, async (req, res) => {
 	const userId = req.session.user.id
 	const publicToken = req.body.public_token
 
@@ -232,7 +232,7 @@ const populateAccountNames = async (userId, accessToken) => {
 
 // plaid endpoints
 
-plaid.get('/accounts/get', async (req, res) => {
+plaid.get('/accounts/get', isAuthenticated, async (req, res) => {
 	const userId = req.session.user.id
 	const partnerId = req.session.user.partner_id
 	const accessToken = await getUserAccessToken(userId)
@@ -256,7 +256,7 @@ plaid.get('/accounts/get', async (req, res) => {
 	}
 })
 
-plaid.get('/transactions/sync', async (req, res) => {
+plaid.get('/transactions/sync', isAuthenticated, async (req, res) => {
 	try {
 		const userId = req.session.user.id
 		const items = await getItemIdsForUser(userId)
@@ -273,7 +273,7 @@ plaid.get('/transactions/sync', async (req, res) => {
 	}
 })
 
-plaid.get('/transactions/list', async (req, res) => {
+plaid.get('/transactions/list', isAuthenticated, async (req, res) => {
 	try {
 		const userId = req.session.user.id
 		const pairId = getPairedId(userId)

--- a/server/routes/plaid.ts
+++ b/server/routes/plaid.ts
@@ -105,7 +105,6 @@ plaid.post('/exchange_public_token', isAuthenticated, async (req, res) => {
 })
 
 // PLAID API ENDPOINTS FOR FETCHING BANK DATA
-
 const syncTransactions = async (item_id) => {
 	const {
 		access_token: accessToken,
@@ -229,8 +228,6 @@ const populateAccountNames = async (userId, accessToken) => {
 		)
 	}
 }
-
-// plaid endpoints
 
 plaid.get('/accounts/get', isAuthenticated, async (req, res) => {
 	const userId = req.session.user.id

--- a/server/routes/plaid.ts
+++ b/server/routes/plaid.ts
@@ -275,13 +275,13 @@ plaid.get('/transactions/sync', async (req, res) => {
 plaid.get('/transactions/list', async (req, res) => {
 	try {
 		const userId = req.session.user.id
-		const maxCount = req.params['maxCount'] ?? 10
+		const maxCount = 10
 		const transactions = await getTransactionsForUser(userId, maxCount)
 
 		res.status(200).json(transactions)
 	} catch (error) {
 		console.log(`Error fetching transactions ${JSON.stringify(error)}`)
-		res.status(500)
+		res.status(500).json({error: error.message})
 	}
 })
 

--- a/server/routes/plaid.ts
+++ b/server/routes/plaid.ts
@@ -15,6 +15,7 @@ import {
 	getItemInfo,
 	getUserAccessToken,
 	isAuthenticated,
+	modifyExistingTransactions,
 	simpleTransactionFromPlaidTransaction,
 } from '../utils/util'
 
@@ -112,6 +113,17 @@ const syncTransactions = async (item_id) => {
 			)
 			console.log(simpleTransaction)
 			await addNewTransaction(simpleTransaction)
+		})
+	)
+
+	await Promise.all(
+		allData.modified.map(async (txnObj) => {
+			const simpleTransaction = simpleTransactionFromPlaidTransaction(
+				txnObj,
+				userId
+			)
+			console.log(simpleTransaction)
+			await modifyExistingTransactions(simpleTransaction)
 		})
 	)
 }

--- a/server/routes/plaid.ts
+++ b/server/routes/plaid.ts
@@ -11,6 +11,7 @@ import {
 } from 'plaid'
 import {
 	addNewTransaction,
+	deleteExistingTransaction,
 	getItemIdsForUser,
 	getItemInfo,
 	getUserAccessToken,
@@ -124,6 +125,12 @@ const syncTransactions = async (item_id) => {
 			)
 			console.log(simpleTransaction)
 			await modifyExistingTransactions(simpleTransaction)
+		})
+	)
+
+	await Promise.all(
+		allData.removed.map(async (txnObj) => {
+			await deleteExistingTransaction(txnObj.transaction_id)
 		})
 	)
 }

--- a/server/routes/plaid.ts
+++ b/server/routes/plaid.ts
@@ -91,12 +91,23 @@ plaid.post('/exchange_public_token', async (req, res) => {
 // PLAID API ENDPOINTS FOR FETCHING BANK DATA
 plaid.get('/accounts', async (req, res) => {
 	const userId = req.session.user.id
+	const partnerId = req.session.user.partner_id
 	const { access_token: accessToken } = await getItemInfo(userId)
+	const { access_token: partnerAccessToken } = await getItemInfo(partnerId)
+	const accounts = {}
 
 	try {
 		const accountsResponse = await plaidClient.accountsGet({
 			access_token: accessToken,
 		})
+		accounts[userId] = accountsResponse.data
+
+		const partnerAccountsResponse = await plaidClient.accountsGet({
+			access_token: partnerAccessToken,
+		})
+		accounts[partnerId] = partnerAccountsResponse.data
+
+		res.status(200).json(accounts)
 	} catch (error) {
 		res.status(500).json({ error: error.message })
 	}

--- a/server/routes/plaid.ts
+++ b/server/routes/plaid.ts
@@ -160,9 +160,9 @@ const fetchNewSyncData = async (accessToken, initialCursor) => {
 		allData.added = allData.added.concat(newData.added)
 		allData.modified = allData.modified.concat(newData.modified)
 		allData.removed = allData.removed.concat(newData.removed)
-		allData.nextCursor = allData.nextCursor
+		allData.nextCursor = newData.next_cursor
 		keepGoing = newData.has_more
-	} while (keepGoing)
+	} while (keepGoing === true)
 
 	console.log(allData)
 	return allData

--- a/server/routes/plaid.ts
+++ b/server/routes/plaid.ts
@@ -245,9 +245,17 @@ plaid.get('/accounts/get', isAuthenticated, async (req, res) => {
 		const partnerAccountsResponse = await plaidClient.accountsGet({
 			access_token: partnerAccessToken,
 		})
-		
-		const userAccount = await extractAccountDetails(accountsResponse.data.accounts, accountsResponse.data.item, userId)
-		const partnerAccount = await extractAccountDetails(partnerAccountsResponse.data.accounts, partnerAccountsResponse.data.item, partnerId)
+
+		const userAccount = await extractAccountDetails(
+			accountsResponse.data.accounts,
+			accountsResponse.data.item,
+			userId
+		)
+		const partnerAccount = await extractAccountDetails(
+			partnerAccountsResponse.data.accounts,
+			partnerAccountsResponse.data.item,
+			partnerId
+		)
 		const accounts = [...userAccount, ...partnerAccount]
 
 		res.status(200).json(accounts)
@@ -278,12 +286,15 @@ plaid.get('/transactions/list', isAuthenticated, async (req, res) => {
 		const userId = req.session.user.id
 		const pairId = getPairedId(userId)
 		const maxCount = 10
-		const transactions = await getTransactionsForUserOrPair(pairId, maxCount)
+		const transactions = await getTransactionsForUserOrPair(
+			pairId,
+			maxCount
+		)
 
 		res.status(200).json(transactions)
 	} catch (error) {
 		console.log(`Error fetching transactions ${JSON.stringify(error)}`)
-		res.status(500).json({error: error.message})
+		res.status(500).json({ error: error.message })
 	}
 })
 

--- a/server/routes/plaid.ts
+++ b/server/routes/plaid.ts
@@ -277,8 +277,11 @@ plaid.get('/transactions/list', async (req, res) => {
 		const userId = req.session.user.id
 		const maxCount = req.params['maxCount'] ?? 10
 		const transactions = await getTransactionsForUser(userId, maxCount)
+
+		res.status(200).json(transactions)
 	} catch (error) {
 		console.log(`Error fetching transactions ${JSON.stringify(error)}`)
+		res.status(500)
 	}
 })
 

--- a/server/utils/util.ts
+++ b/server/utils/util.ts
@@ -106,3 +106,24 @@ export const addNewTransaction = async (transactionObj) => {
 		console.error(error)
 	}
 }
+
+export const modifyExistingTransactions = async (transactionObj) => {
+	try {
+		const updatedTransaction = await prisma.transactions.update({
+			where: { id: transactionObj.id },
+			data: {
+				account_id: transactionObj.account_id,
+				category: transactionObj.category,
+				date: transactionObj.date,
+				authorized_date: transactionObj.authorized_date,
+				name: transactionObj.name,
+				amount: transactionObj.amount,
+				currency_code: transactionObj.currency_code,
+			},
+		})
+
+		return updatedTransaction
+	} catch (error) {
+		console.error(error)
+	}
+}

--- a/server/utils/util.ts
+++ b/server/utils/util.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import { PrismaClient } from '../generated/prisma'
 
 const prisma = new PrismaClient()
@@ -123,6 +124,22 @@ export const modifyExistingTransactions = async (transactionObj) => {
 		})
 
 		return updatedTransaction
+	} catch (error) {
+		console.error(error)
+	}
+}
+
+export const deleteExistingTransaction = async (transaction_id) => {
+	try {
+		const updatedId = transaction_id + '-REMOVED-' + randomUUID()
+		const result = await prisma.transactions.update({
+			where: { id: transaction_id },
+			data: {
+				id: updatedId,
+				is_removed: true,
+			},
+		})
+		return result
 	} catch (error) {
 		console.error(error)
 	}

--- a/server/utils/util.ts
+++ b/server/utils/util.ts
@@ -160,7 +160,45 @@ export const saveCursorForItem = async (transactionCursor, itemId) => {
 
 export const getTransactionsForUser = async (userId, maxNum) => {
 	const transactions = await prisma.transactions.findMany({
-		where: { user_id: userId },
-		orderBy: {}
+		where: { user_id: userId, is_removed: false },
+		include: {
+			account: {
+				include: {
+					item: {
+						select: {
+							bank: true
+						}
+					}
+				},
+
+				select: {
+					name: true
+				}
+			},
+			user: {
+				select: {
+					name: true
+				}
+			}
+		},
+		orderBy: [ { authorized_date: 'desc'} ],
+		take: maxNum
 	})
+
+	const customTransactions = transactions.map(tx => ({
+		id:	tx.id,
+		user_id: tx.user_id,
+		user_name: tx.user.name,
+		account_id: tx.account_id,
+		account_name: tx.account.name,
+		category: tx.category,
+		date: tx.date,
+		authorized_date: tx.authorized_date,
+		transaction_name: tx.name,
+		amount: tx.amount,
+		currency_code: tx.currency_code,
+		is_removed: tx.is_removed,
+	}))
+
+	return customTransactions
 }

--- a/server/utils/util.ts
+++ b/server/utils/util.ts
@@ -144,3 +144,16 @@ export const deleteExistingTransaction = async (transaction_id) => {
 		console.error(error)
 	}
 }
+
+export const saveCursorForItem = async (transactionCursor, itemId) => {
+	try {
+		await prisma.plaidItem.update({
+			where: { id: itemId },
+			data: {
+				transaction_cursor: transactionCursor
+			}
+		})
+	} catch(error) {
+		console.log(`I can't save the cursor ${JSON.stringify(error)}`)
+	}
+}

--- a/server/utils/util.ts
+++ b/server/utils/util.ts
@@ -157,3 +157,10 @@ export const saveCursorForItem = async (transactionCursor, itemId) => {
 		console.log(`I can't save the cursor ${JSON.stringify(error)}`)
 	}
 }
+
+export const getTransactionsForUser = async (userId, maxNum) => {
+	const transactions = await prisma.transactions.findMany({
+		where: { user_id: userId },
+		orderBy: {}
+	})
+}

--- a/server/utils/util.ts
+++ b/server/utils/util.ts
@@ -19,7 +19,7 @@ export const generateHandshakeCode = () => {
 
 	for (let i = 0; i < codeLength; i++) {
 		const randomIndex = Math.floor(Math.random() * letters.length)
-		result += letters.charAt(randomIndex);
+		result += letters.charAt(randomIndex)
 	}
 
 	return result
@@ -30,13 +30,28 @@ export const isExpired = (startDate, secondsToAdd) => {
 	const now = new Date()
 
 	date.setSeconds(date.getSeconds() + secondsToAdd)
-	
+
 	return now > date
 }
 
-export const getItemInfo = async (user_id) => {
+export const getUserAccessToken = async (user_id) => {
 	const item = await prisma.plaidItem.findUnique({
-		where: { owner_id: user_id }
+		where: { owner_id: user_id },
+	})
+
+	return item.access_token
+}
+
+export const getItemIdsForUser = async (userId) => {
+	const items = await prisma.plaidItem.findMany({
+		where: { owner_id: userId },
+	})
+	return items
+}
+
+export const getItemInfo = async (itemId) => {
+	const item = await prisma.plaidItem.findUnique({
+		where: { id: itemId },
 	})
 
 	return item

--- a/server/utils/util.ts
+++ b/server/utils/util.ts
@@ -150,10 +150,10 @@ export const saveCursorForItem = async (transactionCursor, itemId) => {
 		await prisma.plaidItem.update({
 			where: { id: itemId },
 			data: {
-				transaction_cursor: transactionCursor
-			}
+				transaction_cursor: transactionCursor,
+			},
 		})
-	} catch(error) {
+	} catch (error) {
 		console.log(`I can't save the cursor ${JSON.stringify(error)}`)
 	}
 }
@@ -167,23 +167,23 @@ export const getTransactionsForUserOrPair = async (id, max_num) => {
 					name: true,
 					item: {
 						select: {
-							bank: true
-						}
-					}
-				}
+							bank: true,
+						},
+					},
+				},
 			},
 			user: {
 				select: {
-					name: true
-				}
-			}
+					name: true,
+				},
+			},
 		},
-		orderBy: [ { authorized_date: 'desc'} ],
-		take: max_num
+		orderBy: [{ authorized_date: 'desc' }],
+		take: max_num,
 	})
 
-	const customTransactions = transactions.map(tx => ({
-		id:	tx.id,
+	const customTransactions = transactions.map((tx) => ({
+		id: tx.id,
 		user_id: tx.user_id,
 		user_name: tx.user.name,
 		account_id: tx.account_id,
@@ -203,7 +203,7 @@ export const getTransactionsForUserOrPair = async (id, max_num) => {
 
 export const extractAccountDetails = async (accounts, item, userId) => {
 	const name = await getUserNameFromUserId(userId)
-	const customAccounts = accounts.map(acc => ({
+	const customAccounts = accounts.map((acc) => ({
 		id: acc.account_id,
 		account_name: acc.name,
 		bank_name: item.institution_name,
@@ -212,8 +212,7 @@ export const extractAccountDetails = async (accounts, item, userId) => {
 		balances: {
 			available: acc.balances.available,
 			current: acc.balances.current,
-			currency_code: acc.balances.iso_currency_code
-
+			currency_code: acc.balances.iso_currency_code,
 		},
 		subtype: acc.subtype,
 		type: acc.type,
@@ -226,8 +225,8 @@ export const getUserNameFromUserId = async (user_id) => {
 	const user = await prisma.user.findUnique({
 		where: { id: user_id },
 		select: {
-			name: true
-		}
+			name: true,
+		},
 	})
 
 	return user.name
@@ -238,7 +237,7 @@ export const getAccountNameFromAccountId = async (account_id) => {
 		where: { id: account_id },
 		select: {
 			name: true,
-		}
+		},
 	})
 
 	return account.name

--- a/server/utils/util.ts
+++ b/server/utils/util.ts
@@ -36,7 +36,7 @@ export const isExpired = (startDate, secondsToAdd) => {
 }
 
 export const getUserAccessToken = async (user_id) => {
-	const item = await prisma.plaidItem.findUnique({
+	const item = await prisma.plaidItem.findFirst({
 		where: { owner_id: user_id },
 	})
 
@@ -163,16 +163,13 @@ export const getTransactionsForUser = async (userId, maxNum) => {
 		where: { user_id: userId, is_removed: false },
 		include: {
 			account: {
-				include: {
+				select: {
+					name: true,
 					item: {
 						select: {
 							bank: true
 						}
 					}
-				},
-
-				select: {
-					name: true
 				}
 			},
 			user: {
@@ -191,6 +188,7 @@ export const getTransactionsForUser = async (userId, maxNum) => {
 		user_name: tx.user.name,
 		account_id: tx.account_id,
 		account_name: tx.account.name,
+		bank_name: tx.account.item.bank,
 		category: tx.category,
 		date: tx.date,
 		authorized_date: tx.authorized_date,

--- a/server/utils/util.ts
+++ b/server/utils/util.ts
@@ -1,4 +1,8 @@
-const isAuthenticated = (req, res, next) => {
+import { PrismaClient } from '../generated/prisma'
+
+const prisma = new PrismaClient()
+
+export const isAuthenticated = (req, res, next) => {
 	if (!req.session.user) {
 		return res
 			.status(401)
@@ -8,7 +12,7 @@ const isAuthenticated = (req, res, next) => {
 	next()
 }
 
-const generateHandshakeCode = () => {
+export const generateHandshakeCode = () => {
 	const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'
 	let result = ''
 	const codeLength = 5
@@ -21,7 +25,7 @@ const generateHandshakeCode = () => {
 	return result
 }
 
-const isExpired = (startDate, secondsToAdd) => {
+export const isExpired = (startDate, secondsToAdd) => {
 	const date = new Date(startDate)
 	const now = new Date()
 
@@ -30,4 +34,10 @@ const isExpired = (startDate, secondsToAdd) => {
 	return now > date
 }
 
-export { isAuthenticated, generateHandshakeCode, isExpired }
+export const getItemInfo = async (user_id) => {
+	const item = await prisma.plaidItem.findUnique({
+		where: { owner_id: user_id }
+	})
+
+	return item
+}


### PR DESCRIPTION
## Description

This PR was for setting up the transactions API in order to communicate with the Plaid API, calling the transactions plaid API call, reorganizing and adding new tables and columns in the database, and integrating the viewing for each pair's account and transaction information. Later PRs will include UI dashboard design, goals, budgets, and webhook/websocket integration for up to date transactions and user interaction.

## Milestones
User can view their account information
User can view their transaction history
User can view their partner's account information
User can view their partner's transaction history

## Resources
[Plaid Docs](https://plaid.com/docs/api/products/transactions/#transactionssync)
[Prisma Docs](https://www.prisma.io/docs/orm/prisma-client/queries/crud)
[Transactions Plaid Academy](https://www.youtube.com/watch?v=Pin0-ceDKcI)

## Test Plan
I had two accounts created, linked with bank, paired with another user:
* User signups and views their account information on Home page
* User logins and view their account information on Home page
* User signups and view their transaction information on Home page
* User logins and views their transaction information on Home page
* User signups and views their and their partner's account information on Home page
* User logins and view their and their partner's account information on Home page
* User signups and view their and their partner's transaction information on Home page
* User logins and views their and their partner's transaction information on Home page