### PR TITLE
Added retry web socket that exponentially retries to connect to socket

### DIFF
--- a/client/src/contexts/WebsocketContext.tsx
+++ b/client/src/contexts/WebsocketContext.tsx
@@ -29,7 +29,7 @@ export const WebSocketProvider = ({
 				console.log('Websocket connected')
 			}
 
-			ws.onclose = (e) => {
+			ws.onclose = () => {
 				const delay = Math.pow(2, backoffRef.current) * 1000
 				console.warn(
 					`'Websocket closed, will retry soon in ${delay / 1000}s.`

--- a/client/src/contexts/WebsocketContext.tsx
+++ b/client/src/contexts/WebsocketContext.tsx
@@ -30,8 +30,10 @@ export const WebSocketProvider = ({
 			}
 
 			ws.onclose = (e) => {
-				console.warn('Websocket closed, will retry soon.', e)
-				const delay = Math.min(1000 * 2 ** backoffRef.current)
+				const delay = Math.pow(2, backoffRef.current) * 1000
+				console.warn(
+					`'Websocket closed, will retry soon in ${delay / 1000}s.`
+				)
 				backoffRef.current += 1
 				retryTimeoutRef.current = setTimeout(connect, delay)
 			}
@@ -57,7 +59,7 @@ export const WebSocketProvider = ({
 			if (retryTimeoutRef.current) {
 				clearTimeout(retryTimeoutRef.current)
 			}
-			
+
 			if (socket) {
 				socket.close()
 			}

--- a/client/src/contexts/WebsocketContext.tsx
+++ b/client/src/contexts/WebsocketContext.tsx
@@ -1,5 +1,5 @@
 import type React from 'react'
-import { createContext, useContext, useEffect, useState } from 'react'
+import { createContext, useContext, useEffect, useRef, useState } from 'react'
 import { type Notification, type WebSocketContextType } from '../types/types'
 import NotificationToast from '../components/NotificationToast'
 import { useUser } from './UserContext'
@@ -16,34 +16,51 @@ export const WebSocketProvider = ({
 	const [socket, setSocket] = useState<WebSocket | null>(null)
 	const [notification, setNotification] = useState<Notification | null>(null)
 	const { user } = useUser()
+	const backoffRef = useRef<number>(1)
+	const retryTimeoutRef = useRef<any>(null)
 
 	useEffect(() => {
-		const ws = new WebSocket('ws://localhost:3000/')
-		setSocket(ws)
+		const connect = () => {
+			const ws = new WebSocket('ws://localhost:3000/')
+			setSocket(ws)
 
-		ws.onopen = () => {
-			console.log('Websocket connected')
-		}
+			ws.onopen = () => {
+				backoffRef.current = 1
+				console.log('Websocket connected')
+			}
 
-		ws.close = () => {
-			console.log('Websocket disconnected')
-		}
+			ws.onclose = (e) => {
+				console.warn('Websocket closed, will retry soon.', e)
+				const delay = Math.min(1000 * 2 ** backoffRef.current)
+				backoffRef.current += 1
+				retryTimeoutRef.current = setTimeout(connect, delay)
+			}
 
-		ws.onerror = (err) => {
-			console.error('WebSocket error:', err)
-		}
+			ws.onerror = (err) => {
+				console.error('WebSocket error:', err)
+				ws.close()
+			}
 
-		ws.onmessage = (e) => {
-			if (user) {
-				const data = JSON.parse(e.data)
-				setNotification(data)
-			} else {
-				setNotification(null)
+			ws.onmessage = (e) => {
+				if (user) {
+					const data = JSON.parse(e.data)
+					setNotification(data)
+				} else {
+					setNotification(null)
+				}
 			}
 		}
 
+		connect()
+
 		return () => {
-			ws.close()
+			if (retryTimeoutRef.current) {
+				clearTimeout(retryTimeoutRef.current)
+			}
+			
+			if (socket) {
+				socket.close()
+			}
 		}
 	}, [user])
 


### PR DESCRIPTION
## Description

This PR refactors the Web socket context made in previous commits to retry connecting the web socket if the socket could not connect to a socket. Since this is an exponential backoff, it tries to connect every couples of seconds, growing its wait between connections exponentially. Future PRs will be about polishing my TCs and adding more features.

## Milestones
* User will try to reconnect to socket in order to recieve up to date updates for their pair, and will retry after a set exponential delay period

## Resources
[web socket close](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close_event)

## Test Plan
I killed the backend, therefore disabling the connection between server and client, this would in turn give me the retry statement since it'll try to reconnect every 2^(tries) seconds.

<img width="616" height="892" alt="Screenshot 2025-07-21 at 1 58 48 PM" src="https://github.com/user-attachments/assets/16836486-6f29-4d7c-8c51-9077b72350da" />