### PR TITLE
fixed goals modal overlay bug and added x to nofitications

### DIFF
--- a/client/src/components/AddGoalsModal.tsx
+++ b/client/src/components/AddGoalsModal.tsx
@@ -80,7 +80,7 @@ const AddGoalsModal = ({
 	}
 
 	return (
-		<div className="h-screen w-screen bg-stone-950/70 absolute top-0 left-0 flex justify-center items-center">
+		<div className="w-screen h-screen bg-stone-950/70 fixed top-0 left-0 flex justify-center items-center overflow-hidden">
 			<div className="bg-white flex flex-col rounded-2xl border border-gray-300 max-w-md min-w-sm p-8 gap-2 relative">
 				<h1 className="text-xl font-semibold self-start capitalize">
 					add new goal

--- a/client/src/components/AddGoalsModal.tsx
+++ b/client/src/components/AddGoalsModal.tsx
@@ -41,12 +41,12 @@ const AddGoalsModal = ({
 	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault()
 		if (!newGoalData.target) {
-			setError('Target money goal needed')
+			setError('Target goal needed to continue')
 			return
 		}
 
 		if (!is_number(newGoalData.target)) {
-			setError('Target amount must be a number')
+			setError('Target goal must be a number')
 			return
 		}
 
@@ -138,7 +138,7 @@ const AddGoalsModal = ({
 					</Button>
 				</form>
 
-				{error ? <p>{error}</p> : <></>}
+				{error ? <p className='pt-4 text-center font-medium capitalize'>{error}</p> : <></>}
 
 				<Button
 					variant="ghost"

--- a/client/src/components/AddGoalsModal.tsx
+++ b/client/src/components/AddGoalsModal.tsx
@@ -138,7 +138,13 @@ const AddGoalsModal = ({
 					</Button>
 				</form>
 
-				{error ? <p className='pt-4 text-center font-medium capitalize'>{error}</p> : <></>}
+				{error ? (
+					<p className="pt-4 text-center font-medium capitalize">
+						{error}
+					</p>
+				) : (
+					<></>
+				)}
 
 				<Button
 					variant="ghost"

--- a/client/src/components/NotificationToast.tsx
+++ b/client/src/components/NotificationToast.tsx
@@ -9,7 +9,6 @@ import {
 import type { Notification } from '../types/types'
 import { useUser } from '../contexts/UserContext'
 import { useEffect, useState } from 'react'
-import { Button } from './ui/Button'
 
 const NotificationToast = ({
 	notification,

--- a/client/src/components/NotificationToast.tsx
+++ b/client/src/components/NotificationToast.tsx
@@ -4,10 +4,12 @@ import {
 	IconCircleXFilled,
 	IconMoneybag,
 	IconTargetArrow,
+	IconX,
 } from '@tabler/icons-react'
 import type { Notification } from '../types/types'
 import { useUser } from '../contexts/UserContext'
 import { useEffect, useState } from 'react'
+import { Button } from './ui/Button'
 
 const NotificationToast = ({
 	notification,
@@ -133,6 +135,13 @@ const NotificationToast = ({
 					</div>
 				</>
 			)}
+			<IconX
+				size={15}
+				className="absolute top-3 right-3 p-0.5 rounded hover:bg-stone-100"
+				onClick={() => {
+					setShow(false)
+				}}
+			/>
 		</div>
 	)
 }

--- a/client/src/pages/GoalsPage.tsx
+++ b/client/src/pages/GoalsPage.tsx
@@ -60,39 +60,37 @@ const GoalsPage = () => {
 
 	return (
 		<MainLayout>
-			<div>
-				<MainHeader
-					title="Goals"
-					caption={`Set goals with ${
-						user?.partner?.name || 'partner'
-					}`}
+			<MainHeader
+				title="Goals"
+				caption={`Set goals with ${
+					user?.partner?.name || 'partner'
+				}`}
+			>
+				<Button
+					className="flex items-center gap-2 h-fit"
+					onClick={() => setOpenAddGoalsModal(true)}
+					title="Add Goals Button"
 				>
-					<Button
-						className="flex items-center gap-2 h-fit"
-						onClick={() => setOpenAddGoalsModal(true)}
-						title="Add Goals Button"
-					>
-						<IconCirclePlusFilled size={18} />
-						Add Goal
-					</Button>
-				</MainHeader>
-				<div className="flex flex-wrap gap-10 p-4 pt-0 justify-center transition-transform duration-300 ease-in-out will-change-transform">
-					{goals && goals.length > 0 ? (
-						goals.map((goal) => {
-							return (
-								<Goal
-									key={goal.id}
-									title={goal.title}
-									current={goal.current}
-									target={goal.target}
-									onClick={() => handleGoalClick(goal.id)}
-								/>
-							)
-						})
-					) : (
-						<div className="">No goals to see here</div>
-					)}
-				</div>
+					<IconCirclePlusFilled size={18} />
+					Add Goal
+				</Button>
+			</MainHeader>
+			<div className="flex flex-wrap gap-10 p-4 pt-0 justify-center transition-transform duration-300 ease-in-out will-change-transform">
+				{goals && goals.length > 0 ? (
+					goals.map((goal) => {
+						return (
+							<Goal
+								key={goal.id}
+								title={goal.title}
+								current={goal.current}
+								target={goal.target}
+								onClick={() => handleGoalClick(goal.id)}
+							/>
+						)
+					})
+				) : (
+					<div className="">No goals to see here</div>
+				)}
 			</div>
 			{openAddGoalsModal && (
 				<AddGoalsModal


### PR DESCRIPTION
## Description

This PR fixes goals modal overlay bug, that happened whenever someone started to add a new goal. It would not take up the whole screen and break apart when scrolling. Fixing this made it cover the entire screen and stay consisted whenever the user moved around. And this PR added close button to notifications, so it's easy to see and remove it when needed. Next PRs will be about adding stretch features.

## Milestones
User can add goals with bugs
User can dismiss notifications if not wanted

## Resources
None, pure dome

## Test Plan
<img width="447" height="233" alt="Screenshot 2025-07-25 at 2 14 32 PM" src="https://github.com/user-attachments/assets/e3e03d87-4134-4bf1-803f-be184ce2fbf6" />
<img width="1714" height="860" alt="Screenshot 2025-07-25 at 2 14 38 PM" src="https://github.com/user-attachments/assets/d7278628-f1f6-4f6d-8185-a4b4af31094f" />